### PR TITLE
Change the default service name to 'crond' for RHEL based systems.

### DIFF
--- a/logrotate/map.jinja
+++ b/logrotate/map.jinja
@@ -1,7 +1,7 @@
 {% set logrotate = salt['grains.filter_by']({
     'RedHat': {
         'pkg'            : 'logrotate',
-        'service'        : 'cron',
+        'service'        : 'crond',
         'conf_file'      : '/etc/logrotate.conf',
         'include_dir'    : '/etc/logrotate.d',
         'user'           : 'root',
@@ -31,8 +31,4 @@
         'user'           : 'root',
         'group'          : 'root',
     },
-  }, merge=salt['grains.filter_by']({
-    'Fedora': {
-      'service' : 'crond',
-    },
-}, grain='os', merge=salt['pillar.get']('logrotate:lookup'))) %}
+  }, merge=salt['pillar.get']('logrotate:lookup')) %}


### PR DESCRIPTION
The formula doesn't work out-of-box on RHEL based systems (tested on OL 6). It seems that for RHEL 5, 6, 7 versions and Fedoras the name of the cron service is 'crond'.
