### PR TITLE
Pillar configuration structure change to allow file paths with globs

### DIFF
--- a/logrotate/jobs.sls
+++ b/logrotate/jobs.sls
@@ -5,10 +5,10 @@
 include:
   - logrotate
 
-{% for key,value in jobs.iteritems() %}
-{{key}}:
+{% for job_name,value in jobs.iteritems() %}
+{{ value.path }}:
   file.managed:
-    - name: {{ logrotate.include_dir }}/{{ key.split("/")[-1] }}
+    - name: {{ logrotate.include_dir }}/{{ job_name }}
     - source: salt://logrotate/templates/job.tmpl
     - template: jinja
     - user: {{ salt['pillar.get']('logrotate:config:user', logrotate.user) }}
@@ -19,6 +19,6 @@ include:
     - watch_in:
       - service: {{ logrotate.service }}
     - context:
-      path: {{ key }}
-      data: {{ value }}
+      path: {{ value.path }}
+      data: {{ value.data }}
 {%- endfor -%}

--- a/pillar.example
+++ b/pillar.example
@@ -4,12 +4,14 @@ logrotate:
     pkg: logrotate
     service: crond
   jobs:
-    /tmp/var/log/mysql/error:
-      - weekly
-      - missingok
-      - rotate 52
-      - compress
-      - delaycompress
-      - notifempty
-      - create 640 root adm
-      - sharedscripts
+    httpd:
+      path: /var/log/httpd/*log
+      data:
+        - weekly
+        - missingok
+        - rotate 52
+        - compress
+        - delaycompress
+        - notifempty
+        - create 640 root adm
+        - sharedscripts


### PR DESCRIPTION
The original implementation makes it hard to define cleanup rules with globs creating files with names like `/etc/logrotate.d/*logs`. It causes troubles and introduces conflicts between similar jobs.

This change makes it nicer by changing the structure of pillar configuration. Also it is now easier to re-configure logrotate job configurations that are installed from packages.

The downside is that it breaks the backward compatibility with the previous version.
