### PR TITLE
Fix job defaults

### DIFF
--- a/logrotate/jobs.sls
+++ b/logrotate/jobs.sls
@@ -5,7 +5,7 @@
 include:
   - logrotate
 
-{% for key,value in jobs.iteritems() %}
+{% for key,value in jobs.items() %}
 logrotate_{{key}}:
   file.managed:
     - name: {{ logrotate.include_dir }}/{{ key.split("/")[-1] }}

--- a/logrotate/jobs.sls
+++ b/logrotate/jobs.sls
@@ -1,6 +1,6 @@
 # vim: sts=2 ts=2 sw=2 et ai
 {% from "logrotate/map.jinja" import logrotate with context %}
-{% set jobs = salt['pillar.get']('logrotate:jobs') %}
+{% set jobs = salt['pillar.get']('logrotate:jobs', {}) %}
 
 include:
   - logrotate


### PR DESCRIPTION
This defines a proper default value for 'logrotate:jobs' and also improves Py3 compatibility. Please refer to the individual commit messages for slightly more information.
