### PR TITLE
path (if mapping) need to be list now

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -15,7 +15,8 @@ logrotate:
         - create 640 root adm
         - sharedscripts
     mysql:
-      path: /tmp/var/log/mysql/*.log
+      path: 
+        - /tmp/var/log/mysql/*.log
       config:
         - weekly
         - missingok


### PR DESCRIPTION
Since the PR#18 we have broken backward compatibility, if you have this already implemented, "paths" on pillars need to be changed to match the new specification.
