### PR TITLE
Updates logrotate.conf for Debian

### DIFF
--- a/logrotate/files/Debian/logrotate.conf
+++ b/logrotate/files/Debian/logrotate.conf
@@ -2,6 +2,12 @@
 # rotate log files weekly
 weekly
 
+{% if grains['os'] == "Ubuntu" %}
+# use the syslog group by default, since this is the owning group
+# of /var/log/syslog.
+su root syslog
+{% endif %}
+
 # keep 4 weeks worth of backlogs
 rotate 4
 


### PR DESCRIPTION
This logrotate.conf in Ubuntu break logrotate. A few examples

``` bash
rotating pattern: /var/log/wtmp  monthly (1 rotations)
empty log files are rotated, old logs are removed
considering log /var/log/wtmp
error: skipping "/var/log/wtmp" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.

rotating pattern: /var/log/btmp  monthly (1 rotations)
empty log files are rotated, old logs are removed
considering log /var/log/btmp
error: skipping "/var/log/btmp" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
```

/var/log group in debian is syslog.
