### PR TITLE
No need to reload the service on configuration change

### DIFF
--- a/logrotate/config.sls
+++ b/logrotate/config.sls
@@ -13,7 +13,4 @@ logrotate_config:
     - mode: {{ salt['pillar.get']('logrotate:config:mode', '644') }}
     - require:
       - pkg: logrotate
-    - watch_in:
-      - service: {{ logrotate.service }}
-
 

--- a/logrotate/init.sls
+++ b/logrotate/init.sls
@@ -6,7 +6,6 @@ logrotate:
   service.running:
     - name: {{ logrotate.service }}
     - enable: True
-    - reload: True
 
 logrotate_directory:
   file.directory:

--- a/logrotate/jobs.sls
+++ b/logrotate/jobs.sls
@@ -16,8 +16,6 @@ logrotate_{{key}}:
     - mode: {{ salt['pillar.get']('logrotate:config:mode', '644') }}
     - require:
       - pkg: logrotate
-    - watch_in:
-      - service: {{ logrotate.service }}
     - context:
       {% if value is mapping %}
       path: {{ value.get('path', []) }}


### PR DESCRIPTION
No need to reload the cron job or the timer as logrotate will read the configuration file at run time.

Also, reload=True breaks on the default Debian install (the systemd unit does not support reload):
```
salt:~$ sudo systemctl reload cron
Failed to reload cron.service: Job type reload is not applicable for unit cron.service.
```