### PR TITLE
Compress rotated files by default on Debian

### DIFF
--- a/logrotate/map.jinja
+++ b/logrotate/map.jinja
@@ -10,6 +10,11 @@
                 'tabooext': '+ .pacorig .pacnew .pacsave',
             },
         },
+        'Debian': {
+            'default_config': {
+                'compress': True,
+            },
+        },
         'RedHat': {
             'service': 'crond',
             'default_config': {


### PR DESCRIPTION
Compress is enabled by default on Debian.