### PR TITLE
Fixed jobs indentation

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -10,7 +10,7 @@ logrotate:
     compress: True
     dateext: True
   jobs:
-      /tmp/var/log/mysql/error:
+    /tmp/var/log/mysql/error:
       config:
         - weekly
         - missingok


### PR DESCRIPTION
Was getting error:

> [CRITICAL] Rendering SLS 'logrotate' failed, render error:
> while parsing a block mapping
>   in "<string>", line 3, column 3:
>       lookup:
>       ^
> expected <block end>, but found '<block mapping start>'
>   in "<string>", line 23, column 5:
>         mysql:
>         ^
> [CRITICAL] Pillar render error: Rendering SLS 'logrotate' failed. Please see master log for details.
> local:
>     Data failed to compile:
> Pillar failed to render with the following messages:
> Rendering SLS 'logrotate' failed. Please see master log for details.
