### PR TITLE
Context data wrapped with tojson filter.

### DIFF
--- a/logrotate/jobs.sls
+++ b/logrotate/jobs.sls
@@ -22,11 +22,11 @@ logrotate-{{ key }}:
     - template: jinja
     - context:
       {% if value is mapping %}
-      path: {{ value.get('path', [key]) | tojson }}
-      data: {{ value.get('config', []) | tojson }}
+      path: {{ value.get('path', [key]) | json }}
+      data: {{ value.get('config', []) | json }}
       {% else %}
-      path: [ {{ key | tojson }} ]
-      data: {{ value | tojson }}
+      path: [ {{ key | json }} ]
+      data: {{ value | json }}
       {% endif %}
     {% endif %}
 {%- endfor -%}

--- a/logrotate/jobs.sls
+++ b/logrotate/jobs.sls
@@ -22,11 +22,11 @@ logrotate-{{ key }}:
     - template: jinja
     - context:
       {% if value is mapping %}
-      path: {{ value.get('path', [key]) }}
-      data: {{ value.get('config', []) }}
+      path: {{ value.get('path', [key]) | tojson }}
+      data: {{ value.get('config', []) | tojson }}
       {% else %}
-      path: [ {{ key }} ]
-      data: {{ value }}
+      path: [ {{ key | tojson }} ]
+      data: {{ value | tojson }}
       {% endif %}
     {% endif %}
 {%- endfor -%}


### PR DESCRIPTION
The data was being prepended with 'u' characters. This should address [Issue 41](https://github.com/saltstack-formulas/logrotate-formula/issues/41)