### PR TITLE
fix: corrected indentation on context in file.managed states

### DIFF
--- a/logrotate/jobs.sls
+++ b/logrotate/jobs.sls
@@ -22,11 +22,11 @@ logrotate-{{ key }}:
     - template: jinja
     - context:
       {% if value is mapping %}
-      path: {{ value.get('path', [key]) | json }}
-      data: {{ value.get('config', []) | json }}
+        path: {{ value.get('path', [key]) | json }}
+        data: {{ value.get('config', []) | json }}
       {% else %}
-      path: [ {{ key | json }} ]
-      data: {{ value | json }}
+        path: [ {{ key | json }} ]
+        data: {{ value | json }}
       {% endif %}
     {% endif %}
 {%- endfor -%}


### PR DESCRIPTION
When indentation in `context` is wrong, it can lead to errors, see https://github.com/daks/saltbug-formula for an example.