### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/logrotate/defaults.yaml
+++ b/logrotate/defaults.yaml
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
-
+---
 logrotate:
   pkg: logrotate
   conf_file: '/etc/logrotate.conf'
@@ -8,9 +8,8 @@ logrotate:
   user: root
   group: root
   service: cron
-  login_records_jobs: True
+  login_records_jobs: true
   default_config:
-    weekly: True
+    weekly: true
     rotate: 4
-    create: True
-
+    create: true

--- a/logrotate/osfamilymap.yaml
+++ b/logrotate/osfamilymap.yaml
@@ -1,19 +1,22 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 Arch:
   service: logrotate.timer
   default_config:
     tabooext: + .pacorig .pacnew .pacsave
 Debian:
   default_config:
-    compress: True
+    compress: true
 RedHat:
   pkg: cronie
   service: crond
   default_config:
-    dateext: True
+    dateext: true
 Suse:
-  login_records_jobs: False
+  login_records_jobs: false
   default_config:
-    dateext: True
+    dateext: true
     compresscmd: /usr/bin/xz
     uncompresscmd: /usr/bin/xzdec
 Gentoo:
@@ -21,7 +24,7 @@ Gentoo:
   service: cronie
   default_config:
     tabooext: + .keep
-    dateext: True
+    dateext: true
 FreeBSD:
   conf_file: /usr/local/etc/logrotate.conf
   include_dir: /usr/local/etc/logrotate.d

--- a/logrotate/osmap.yaml
+++ b/logrotate/osmap.yaml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 Ubuntu:
   default_config:
     su: root syslog

--- a/pillar.example
+++ b/pillar.example
@@ -1,16 +1,17 @@
-# vim: sts=2 ts=2 sw=2 et ai
-
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 logrotate:
   # default OS values can be overridden in 'lookup' dict
-  #lookup:
-    #pkg: logrotate
-    #service: crond
+  # lookup:
+  #   pkg: logrotate
+  #   service: crond
   default_config:
-    weekly: True
+    weekly: true
     rotate: 52
-    create: True
-    compress: True
-    dateext: True
+    create: true
+    compress: true
+    dateext: true
   jobs:
     /tmp/var/log/mysql/error:
       config:
@@ -23,7 +24,7 @@ logrotate:
         - create 640 root adm
         - sharedscripts
     mysql:
-      path: 
+      path:
         - /tmp/var/log/mysql/*.log
       config:
         - weekly
@@ -45,7 +46,7 @@ logrotate:
       config:
         - sharedscripts
         - postrotate
-        -   /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
+        - /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
         - endscript
     nginx:
       contents: |
@@ -66,4 +67,3 @@ logrotate:
             invoke-rc.d nginx rotate >/dev/null 2>&1
           endscript
         }
-

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: logrotate formula
 maintainer: SaltStack Formulas


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
logrotate-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./logrotate/osmap.yaml
  1:1       warning  missing document start "---"  (document-start)

./logrotate/osfamilymap.yaml
  1:1       warning  missing document start "---"  (document-start)
  7:15      warning  truthy value should be one of [false, true]  (truthy)
  12:14     warning  truthy value should be one of [false, true]  (truthy)
  14:23     warning  truthy value should be one of [false, true]  (truthy)
  16:14     warning  truthy value should be one of [false, true]  (truthy)
  24:14     warning  truthy value should be one of [false, true]  (truthy)

./logrotate/defaults.yaml
  4:1       warning  missing document start "---"  (document-start)
  11:23     warning  truthy value should be one of [false, true]  (truthy)
  13:13     warning  truthy value should be one of [false, true]  (truthy)
  15:13     warning  truthy value should be one of [false, true]  (truthy)
  16:1      error    too many blank lines (1 > 0)  (empty-lines)

pillar.example
  3:1       warning  missing document start "---"  (document-start)
  5:4       warning  missing starting space in comment  (comments)
  6:6       warning  missing starting space in comment  (comments)
  6:5       warning  comment not indented like content  (comments-indentation)
  7:6       warning  missing starting space in comment  (comments)
  9:13      warning  truthy value should be one of [false, true]  (truthy)
  11:13     warning  truthy value should be one of [false, true]  (truthy)
  12:15     warning  truthy value should be one of [false, true]  (truthy)
  13:14     warning  truthy value should be one of [false, true]  (truthy)
  26:12     error    trailing spaces  (trailing-spaces)
  48:12     error    too many spaces after hyphen  (hyphens)
  69:1      error    too many blank lines (1 > 0)  (empty-lines)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.