### PR TITLE
fix(debian): disable login_records, they are managed by the package

### DIFF
--- a/logrotate/osfamilymap.yaml
+++ b/logrotate/osfamilymap.yaml
@@ -6,6 +6,7 @@ Arch:
   default_config:
     tabooext: + .pacorig .pacnew .pacsave
 Debian:
+  login_records_jobs: false
   default_config:
     compress: true
 RedHat:

--- a/logrotate/osfingermap.yaml
+++ b/logrotate/osfingermap.yaml
@@ -11,7 +11,4 @@
 # osfingermap: {}
 ---
 # os: Debian
-Debian-10:
-  login_records_jobs: false
-Debian-11:
-  login_records_jobs: false
+osfingermap: {}


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [x] `[fix]`      A bug fix


### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

This has been the case since Debian Buster, and Stretch has been EOL for a long time, so we can drop the old behaviour.

